### PR TITLE
Update Currency.swift

### DIFF
--- a/Sources/CurrencyProviding/Currency.swift
+++ b/Sources/CurrencyProviding/Currency.swift
@@ -256,7 +256,7 @@ public enum Currency: String, Identifiable, Hashable, CaseIterable {
     public var currencyCode: String {
         switch self {
         case .austral:
-            return "ARS"
+            return "ARA"
         case .baht:
             return "THB"
         case .brazilianreal:


### PR DESCRIPTION
Corrected the ISO code for Argentinian Austral to ARA instead of ARS